### PR TITLE
Feat/auth : 소셜 로그인 추가 및 페이지 이동

### DIFF
--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -1,0 +1,11 @@
+import Onboarding from "@/components/auth/Onboarding";
+
+const OnboardingPage = () => {
+  return (
+    <section>
+      <Onboarding />
+    </section>
+  );
+};
+
+export default OnboardingPage;

--- a/src/components/auth/Onboarding.tsx
+++ b/src/components/auth/Onboarding.tsx
@@ -1,0 +1,5 @@
+const Onboarding = () => {
+  return <div>hello,world!</div>;
+};
+
+export default Onboarding;

--- a/src/components/auth/SignIn.tsx
+++ b/src/components/auth/SignIn.tsx
@@ -7,6 +7,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { Input } from "../ui/input";
 import { Button } from "../ui/button";
 import { createClient } from "@supabase/supabase-js";
+import { useState } from "react";
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL as string;
 const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string;
@@ -19,6 +20,9 @@ type AuthFormInputs = {
 };
 
 const SignIn = () => {
+  // 비밀번호 표시 상태 관리
+  const [showPassword, setShowPassword] = useState(false);
+
   const defaultValues = {
     email: "",
     password: ""
@@ -114,11 +118,19 @@ const SignIn = () => {
             <FormItem>
               <FormLabel className="text-gray-600">비밀번호</FormLabel>
               <FormControl>
-                <Input
-                  className={form.formState.errors.password ? "border-red-500" : "border-gray-300"}
-                  placeholder="PASSWORD"
-                  {...field}
-                />
+                <>
+                  <Input
+                    className={form.formState.errors.password ? "border-red-500" : "border-gray-300"}
+                    type={showPassword ? "text" : "password"}
+                    placeholder="PASSWORD"
+                    {...field}
+                  />
+                  <label>
+                    <Button type="button" onClick={() => setShowPassword(!showPassword)}>
+                      {showPassword ? <p>숨기기</p> : <p>보이기</p>}
+                    </Button>
+                  </label>
+                </>
               </FormControl>
               <FormDescription className={form.formState.errors.password ? "text-red-500" : "text-gray-600"}>
                 {form.formState.errors.password?.message}
@@ -128,9 +140,10 @@ const SignIn = () => {
         />
 
         <Button type="submit">로그인</Button>
-        <Button onClick={googleSignIn}>구글로그인</Button>
-        <Button onClick={kakaoSignIn}>카카오로그인</Button>
+        <Button>회원가입</Button>
       </form>
+      <Button onClick={googleSignIn}>구글로그인</Button>
+      <Button onClick={kakaoSignIn}>카카오로그인</Button>
     </Form>
   );
 };

--- a/src/components/auth/SignIn.tsx
+++ b/src/components/auth/SignIn.tsx
@@ -6,13 +6,9 @@ import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Input } from "../ui/input";
 import { Button } from "../ui/button";
-import { createClient } from "@supabase/supabase-js";
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL as string;
-const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string;
-const supabase = createClient(supabaseUrl, supabaseKey);
+import browserClient from "@/utils/supabase/client";
 
 // 임시로 타입 지정 추후에 타입 파일에 추가 예정
 type AuthFormInputs = {
@@ -45,7 +41,7 @@ const SignIn = () => {
 
   const signIn = async (data: AuthFormInputs) => {
     try {
-      const { error } = await supabase.auth.signInWithPassword({
+      const { error } = await browserClient.auth.signInWithPassword({
         email: data.email,
         password: data.password
       });
@@ -61,7 +57,7 @@ const SignIn = () => {
   };
 
   const googleSignIn = async () => {
-    const { data, error } = await supabase.auth.signInWithOAuth({
+    const { data, error } = await browserClient.auth.signInWithOAuth({
       provider: "google",
       options: {
         queryParams: {
@@ -77,7 +73,7 @@ const SignIn = () => {
   };
 
   const kakaoSignIn = async () => {
-    const { data, error } = await supabase.auth.signInWithOAuth({
+    const { data, error } = await browserClient.auth.signInWithOAuth({
       provider: "kakao",
       options: {
         queryParams: {

--- a/src/components/auth/SignIn.tsx
+++ b/src/components/auth/SignIn.tsx
@@ -8,6 +8,7 @@ import { Input } from "../ui/input";
 import { Button } from "../ui/button";
 import { createClient } from "@supabase/supabase-js";
 import { useState } from "react";
+import { useRouter } from "next/navigation";
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL as string;
 const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string;
@@ -22,6 +23,8 @@ type AuthFormInputs = {
 const SignIn = () => {
   // 비밀번호 표시 상태 관리
   const [showPassword, setShowPassword] = useState(false);
+
+  const router = useRouter();
 
   const defaultValues = {
     email: "",
@@ -51,6 +54,7 @@ const SignIn = () => {
 
       alert("로그인 성공!");
       console.log("로그인 데이터:", data);
+      router.push("/");
     } catch (error) {
       console.error("로그인 실패:", error);
     }

--- a/src/components/auth/SignIn.tsx
+++ b/src/components/auth/SignIn.tsx
@@ -52,6 +52,38 @@ const SignIn = () => {
     }
   };
 
+  const googleSignIn = async () => {
+    const { data, error } = await supabase.auth.signInWithOAuth({
+      provider: "google",
+      options: {
+        queryParams: {
+          access_type: "offline",
+          prompt: "consent"
+        }
+      }
+    });
+
+    if (data) console.log("로그인 데이터 : ", data);
+
+    if (error) console.log("로그인 실패 : ", error);
+  };
+
+  const kakaoSignIn = async () => {
+    const { data, error } = await supabase.auth.signInWithOAuth({
+      provider: "kakao",
+      options: {
+        queryParams: {
+          access_type: "offline",
+          prompt: "consent"
+        }
+      }
+    });
+
+    if (data) console.log("로그인 데이터 : ", data);
+
+    if (error) console.log("로그인 실패 : ", error);
+  };
+
   return (
     <Form {...form}>
       <form onSubmit={form.handleSubmit(signIn)}>
@@ -96,6 +128,8 @@ const SignIn = () => {
         />
 
         <Button type="submit">로그인</Button>
+        <Button onClick={googleSignIn}>구글로그인</Button>
+        <Button onClick={kakaoSignIn}>카카오로그인</Button>
       </form>
     </Form>
   );

--- a/src/components/auth/SignOut.tsx
+++ b/src/components/auth/SignOut.tsx
@@ -1,0 +1,17 @@
+import { createClient } from "@supabase/supabase-js";
+import { Button } from "../ui/button";
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL as string;
+const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string;
+const supabase = createClient(supabaseUrl, supabaseKey);
+
+const SignOut = () => {
+  const handleSignOut = async () => {
+    await supabase.auth.signOut();
+    alert("로그아웃 되었습니다. 메인페이지로 이동합니다.");
+    // 이동해야해
+  };
+  return <Button onClick={handleSignOut}>로그아웃</Button>;
+};
+
+export default SignOut;

--- a/src/components/auth/SignOut.tsx
+++ b/src/components/auth/SignOut.tsx
@@ -1,13 +1,9 @@
-import { createClient } from "@supabase/supabase-js";
 import { Button } from "../ui/button";
-
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL as string;
-const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string;
-const supabase = createClient(supabaseUrl, supabaseKey);
+import browserClient from "@/utils/supabase/client";
 
 const SignOut = () => {
   const handleSignOut = async () => {
-    await supabase.auth.signOut();
+    await browserClient.auth.signOut();
     alert("로그아웃 되었습니다. 메인페이지로 이동합니다.");
     // 이동해야해
   };

--- a/src/components/auth/SignUp.tsx
+++ b/src/components/auth/SignUp.tsx
@@ -8,6 +8,7 @@ import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Input } from "../ui/input";
 import { Button } from "../ui/button";
+import { useRouter } from "next/navigation";
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL as string;
 const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string;
@@ -25,6 +26,8 @@ const SignUp = () => {
   // 비밀번호 표시 상태 관리
   const [showPassword, setShowPassword] = useState(false);
   const [showPasswordCheck, setShowPasswordCheck] = useState(false);
+
+  const router = useRouter();
 
   const defaultValues = {
     email: "",
@@ -82,6 +85,7 @@ const SignUp = () => {
 
       alert("회원가입 성공!");
       console.log("회원가입 데이터:", data);
+      router.push("/onboarding");
     } catch (error) {
       console.error("회원가입 실패:", error);
       alert("이미 가입 된 정보입니다"); //error case 좀 알아보고 에러별 alert 작성해야할듯

--- a/src/components/auth/SignUp.tsx
+++ b/src/components/auth/SignUp.tsx
@@ -24,6 +24,7 @@ type AuthFormInputs = {
 const SignUp = () => {
   // 비밀번호 표시 상태 관리
   const [showPassword, setShowPassword] = useState(false);
+  const [showPasswordCheck, setShowPasswordCheck] = useState(false);
 
   const defaultValues = {
     email: "",
@@ -145,12 +146,19 @@ const SignUp = () => {
             <FormItem>
               <FormLabel className="text-gray-600">비밀번호 확인</FormLabel>
               <FormControl>
-                <Input
-                  className={form.formState.errors.passwordCheck ? "border-red-500" : "border-gray-300"}
-                  type="password"
-                  placeholder="PASSWORD"
-                  {...field}
-                />
+                <>
+                  <Input
+                    className={form.formState.errors.passwordCheck ? "border-red-500" : "border-gray-300"}
+                    type={showPasswordCheck ? "text" : "password"}
+                    placeholder="PASSWORD"
+                    {...field}
+                  />
+                  <label>
+                    <Button type="button" onClick={() => setShowPasswordCheck(!showPasswordCheck)}>
+                      {showPasswordCheck ? <p>숨기기</p> : <p>보이기</p>}
+                    </Button>
+                  </label>
+                </>
               </FormControl>
               <FormDescription className={form.formState.errors.passwordCheck ? "text-red-500" : "text-gray-600"}>
                 {form.formState.errors.passwordCheck?.message}

--- a/src/components/auth/SignUp.tsx
+++ b/src/components/auth/SignUp.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { createClient } from "@supabase/supabase-js";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel } from "../ui/form";
@@ -9,10 +8,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { Input } from "../ui/input";
 import { Button } from "../ui/button";
 import { useRouter } from "next/navigation";
-
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL as string;
-const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string;
-const supabase = createClient(supabaseUrl, supabaseKey);
+import browserClient from "@/utils/supabase/client";
 
 // 임시로 타입 지정 추후에 타입 파일에 추가 예정
 type AuthFormInputs = {
@@ -71,7 +67,7 @@ const SignUp = () => {
 
   const signUp = async (data: AuthFormInputs) => {
     try {
-      const { error } = await supabase.auth.signUp({
+      const { error } = await browserClient.auth.signUp({
         email: data.email,
         password: data.password,
         options: {


### PR DESCRIPTION
## 🔥 작업 내용

- 소셜 로그인 추가 (구글, 카카오)
- 로그인 시 페이지 이동
- 기타 소소한 디테일 수정

## 📸 스크린샷

- 구글 로그인
<img src = "https://media.discordapp.net/attachments/1244516648866680885/1300792364712988712/2024-10-299.00.55-ezgif.com-video-to-gif-converter.gif?ex=672220cb&is=6720cf4b&hm=e6e83b0f321da62e5c575216bc516cb6b4c4642812905c046395982026b5d25e&=&width=1100&height=688">

- 카카오 로그인
<img src = "https://media.discordapp.net/attachments/1244516648866680885/1300792589028425739/2024-10-299.01.44-ezgif.com-video-to-gif-converter.gif?ex=67222100&is=6720cf80&hm=9429d813366674d42e02c48a521d20a53b34b63f0bf08219bf929b0c2a1d6494&=&width=1100&height=688">

## 💁🏻‍♀️ 테스트 체크리스트

- 소셜 로그인 : 구글과 카카오에서 제대로 로그인창이 받아와지고 로그인 후 메인 페이지로 이동 확인
- 로그인 시 헬퍼텍스트가 랜더링 되는 오류가 있었지만 수정하여 지금은 바로 넘어가짐
- 로그인 후 유져 데이터도 잘 불러와짐

## 👍 참고 사항

- 관련된 이슈나 참고할 사항을 적어주세요!
-
