### PR TITLE
Feat/child calendar: 아이카드 일정표에 접종 일정 보여주기 및 캐러셀 적용 완료

### DIFF
--- a/database.types.ts
+++ b/database.types.ts
@@ -1,249 +1,303 @@
-export type Json = string | number | boolean | null | { [key: string]: Json | undefined } | Json[];
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[]
 
 export type Database = {
   public: {
     Tables: {
       child: {
         Row: {
-          birth: string | null;
-          created_at: string;
-          id: string;
-          name: string | null;
-          profile: string | null;
-          updated_at: string | null;
-          user_id: string | null;
-        };
+          birth: string
+          created_at: string
+          id: string
+          name: string
+          notes: string
+          profile: string
+          updated_at: string
+          user_id: string
+        }
         Insert: {
-          birth?: string | null;
-          created_at?: string;
-          id?: string;
-          name?: string | null;
-          profile?: string | null;
-          updated_at?: string | null;
-          user_id?: string | null;
-        };
+          birth?: string
+          created_at?: string
+          id?: string
+          name?: string
+          notes?: string
+          profile?: string
+          updated_at?: string
+          user_id?: string
+        }
         Update: {
-          birth?: string | null;
-          created_at?: string;
-          id?: string;
-          name?: string | null;
-          profile?: string | null;
-          updated_at?: string | null;
-          user_id?: string | null;
-        };
-        Relationships: [];
-      };
+          birth?: string
+          created_at?: string
+          id?: string
+          name?: string
+          notes?: string
+          profile?: string
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
       user: {
         Row: {
-          created_at: string;
-          email: string | null;
-          id: string;
-          nickname: string | null;
-          updated_at: string | null;
-          user_id: string | null;
-        };
+          created_at: string
+          email: string
+          id: string
+          name: string
+          updated_at: string
+          user_id: string
+        }
         Insert: {
-          created_at?: string;
-          email?: string | null;
-          id?: string;
-          nickname?: string | null;
-          updated_at?: string | null;
-          user_id?: string | null;
-        };
+          created_at?: string
+          email?: string
+          id?: string
+          name?: string
+          updated_at?: string
+          user_id?: string
+        }
         Update: {
-          created_at?: string;
-          email?: string | null;
-          id?: string;
-          nickname?: string | null;
-          updated_at?: string | null;
-          user_id?: string | null;
-        };
-        Relationships: [];
-      };
+          created_at?: string
+          email?: string
+          id?: string
+          name?: string
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
       vaccine: {
         Row: {
-          additional: boolean;
-          description: string | null;
-          disease_name: string | null;
-          duration: string | null;
-          id: string;
-          vaccinate_date: number | null;
-          vaccine_name: string | null;
-          vaccine_turn: number | null;
-        };
+          additional: boolean
+          description: string
+          disease_name: string
+          duration: string
+          id: string
+          vaccinate_date: number
+          vaccine_name: string
+          vaccine_turn: number
+        }
         Insert: {
-          additional?: boolean;
-          description?: string | null;
-          disease_name?: string | null;
-          duration?: string | null;
-          id: string;
-          vaccinate_date?: number | null;
-          vaccine_name?: string | null;
-          vaccine_turn?: number | null;
-        };
+          additional?: boolean
+          description?: string
+          disease_name?: string
+          duration?: string
+          id?: string
+          vaccinate_date?: number
+          vaccine_name?: string
+          vaccine_turn?: number
+        }
         Update: {
-          additional?: boolean;
-          description?: string | null;
-          disease_name?: string | null;
-          duration?: string | null;
-          id?: string;
-          vaccinate_date?: number | null;
-          vaccine_name?: string | null;
-          vaccine_turn?: number | null;
-        };
-        Relationships: [];
-      };
+          additional?: boolean
+          description?: string
+          disease_name?: string
+          duration?: string
+          id?: string
+          vaccinate_date?: number
+          vaccine_name?: string
+          vaccine_turn?: number
+        }
+        Relationships: []
+      }
+      vaccine_duplicate: {
+        Row: {
+          description: string
+          disease_name: string
+          id: string
+          process: string
+          target: string
+          vaccinate_date: string
+          vaccine_name: string
+          vaccine_turn: string
+        }
+        Insert: {
+          description?: string
+          disease_name?: string
+          id?: string
+          process?: string
+          target?: string
+          vaccinate_date?: string
+          vaccine_name?: string
+          vaccine_turn?: string
+        }
+        Update: {
+          description?: string
+          disease_name?: string
+          id?: string
+          process?: string
+          target?: string
+          vaccinate_date?: string
+          vaccine_name?: string
+          vaccine_turn?: string
+        }
+        Relationships: []
+      }
       vaccine_record: {
         Row: {
-          child_id: string | null;
-          created_at: string;
-          id: string;
-          vaccine_id: string | null;
-        };
+          child_id: string
+          created_at: string
+          id: string
+          vaccine_id: string
+        }
         Insert: {
-          child_id?: string | null;
-          created_at?: string;
-          id?: string;
-          vaccine_id?: string | null;
-        };
+          child_id?: string
+          created_at?: string
+          id?: string
+          vaccine_id?: string
+        }
         Update: {
-          child_id?: string | null;
-          created_at?: string;
-          id?: string;
-          vaccine_id?: string | null;
-        };
+          child_id?: string
+          created_at?: string
+          id?: string
+          vaccine_id?: string
+        }
         Relationships: [
           {
-            foreignKeyName: "vaccine_record_child_id_fkey";
-            columns: ["child_id"];
-            isOneToOne: false;
-            referencedRelation: "child";
-            referencedColumns: ["id"];
+            foreignKeyName: "vaccine_record_child_id_fkey"
+            columns: ["child_id"]
+            isOneToOne: false
+            referencedRelation: "child"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "vaccine_record_vaccine_id_fkey";
-            columns: ["vaccine_id"];
-            isOneToOne: false;
-            referencedRelation: "vaccine";
-            referencedColumns: ["id"];
-          }
-        ];
-      };
+            foreignKeyName: "vaccine_record_vaccine_id_fkey"
+            columns: ["vaccine_id"]
+            isOneToOne: false
+            referencedRelation: "vaccine"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       vaccineinfo: {
         Row: {
-          description: string;
-          disease_name: string;
-          vaccinate_date: string | null;
-        };
+          description: string
+          disease_name: string
+          vaccinate_date: string
+        }
         Insert: {
-          description: string;
-          disease_name: string;
-          vaccinate_date?: string | null;
-        };
+          description?: string
+          disease_name?: string
+          vaccinate_date?: string
+        }
         Update: {
-          description?: string;
-          disease_name?: string;
-          vaccinate_date?: string | null;
-        };
-        Relationships: [];
-      };
-    };
+          description?: string
+          disease_name?: string
+          vaccinate_date?: string
+        }
+        Relationships: []
+      }
+    }
     Views: {
-      [_ in never]: never;
-    };
+      [_ in never]: never
+    }
     Functions: {
-      [_ in never]: never;
-    };
+      [_ in never]: never
+    }
     Enums: {
-      [_ in never]: never;
-    };
+      [_ in never]: never
+    }
     CompositeTypes: {
-      [_ in never]: never;
-    };
-  };
-};
+      [_ in never]: never
+    }
+  }
+}
 
-type PublicSchema = Database[Extract<keyof Database, "public">];
+type PublicSchema = Database[Extract<keyof Database, "public">]
 
 export type Tables<
-  PublicTableNameOrOptions extends keyof (PublicSchema["Tables"] & PublicSchema["Views"]) | { schema: keyof Database },
+  PublicTableNameOrOptions extends
+    | keyof (PublicSchema["Tables"] & PublicSchema["Views"])
+    | { schema: keyof Database },
   TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
     ? keyof (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
         Database[PublicTableNameOrOptions["schema"]]["Views"])
-    : never = never
+    : never = never,
 > = PublicTableNameOrOptions extends { schema: keyof Database }
   ? (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
       Database[PublicTableNameOrOptions["schema"]]["Views"])[TableName] extends {
-      Row: infer R;
+      Row: infer R
     }
     ? R
     : never
-  : PublicTableNameOrOptions extends keyof (PublicSchema["Tables"] & PublicSchema["Views"])
-  ? (PublicSchema["Tables"] & PublicSchema["Views"])[PublicTableNameOrOptions] extends {
-      Row: infer R;
-    }
-    ? R
+  : PublicTableNameOrOptions extends keyof (PublicSchema["Tables"] &
+        PublicSchema["Views"])
+    ? (PublicSchema["Tables"] &
+        PublicSchema["Views"])[PublicTableNameOrOptions] extends {
+        Row: infer R
+      }
+      ? R
+      : never
     : never
-  : never;
 
 export type TablesInsert<
-  PublicTableNameOrOptions extends keyof PublicSchema["Tables"] | { schema: keyof Database },
+  PublicTableNameOrOptions extends
+    | keyof PublicSchema["Tables"]
+    | { schema: keyof Database },
   TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
     ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
-    : never = never
+    : never = never,
 > = PublicTableNameOrOptions extends { schema: keyof Database }
   ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
-      Insert: infer I;
+      Insert: infer I
     }
     ? I
     : never
   : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
-  ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
-      Insert: infer I;
-    }
-    ? I
+    ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
+        Insert: infer I
+      }
+      ? I
+      : never
     : never
-  : never;
 
 export type TablesUpdate<
-  PublicTableNameOrOptions extends keyof PublicSchema["Tables"] | { schema: keyof Database },
+  PublicTableNameOrOptions extends
+    | keyof PublicSchema["Tables"]
+    | { schema: keyof Database },
   TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
     ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
-    : never = never
+    : never = never,
 > = PublicTableNameOrOptions extends { schema: keyof Database }
   ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
-      Update: infer U;
+      Update: infer U
     }
     ? U
     : never
   : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
-  ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
-      Update: infer U;
-    }
-    ? U
+    ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
+        Update: infer U
+      }
+      ? U
+      : never
     : never
-  : never;
 
 export type Enums<
-  PublicEnumNameOrOptions extends keyof PublicSchema["Enums"] | { schema: keyof Database },
+  PublicEnumNameOrOptions extends
+    | keyof PublicSchema["Enums"]
+    | { schema: keyof Database },
   EnumName extends PublicEnumNameOrOptions extends { schema: keyof Database }
     ? keyof Database[PublicEnumNameOrOptions["schema"]]["Enums"]
-    : never = never
+    : never = never,
 > = PublicEnumNameOrOptions extends { schema: keyof Database }
   ? Database[PublicEnumNameOrOptions["schema"]]["Enums"][EnumName]
   : PublicEnumNameOrOptions extends keyof PublicSchema["Enums"]
-  ? PublicSchema["Enums"][PublicEnumNameOrOptions]
-  : never;
+    ? PublicSchema["Enums"][PublicEnumNameOrOptions]
+    : never
 
 export type CompositeTypes<
-  PublicCompositeTypeNameOrOptions extends keyof PublicSchema["CompositeTypes"] | { schema: keyof Database },
+  PublicCompositeTypeNameOrOptions extends
+    | keyof PublicSchema["CompositeTypes"]
+    | { schema: keyof Database },
   CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
-    schema: keyof Database;
+    schema: keyof Database
   }
     ? keyof Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
-    : never = never
+    : never = never,
 > = PublicCompositeTypeNameOrOptions extends { schema: keyof Database }
   ? Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
   : PublicCompositeTypeNameOrOptions extends keyof PublicSchema["CompositeTypes"]
-  ? PublicSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
-  : never;
+    ? PublicSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+    : never

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
+    "embla-carousel-react": "^8.3.1",
     "fast-xml-parser": "^4.5.0",
     "lucide-react": "^0.453.0",
     "next": "14.2.15",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@tanstack/react-query-devtools": "^5.59.16",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
+    "date-fns": "^4.1.0",
     "fast-xml-parser": "^4.5.0",
     "lucide-react": "^0.453.0",
     "next": "14.2.15",

--- a/src/api/userApi.ts
+++ b/src/api/userApi.ts
@@ -37,12 +37,12 @@ export const getChildren = async (supabaseClient: SupabaseDatabase, userId?: str
 
     if (error) {
       console.error(error.message);
-      return;
+      return [];
     }
 
     return data;
   } else {
-    return;
+    return [];
   }
 };
 

--- a/src/api/userApi.ts
+++ b/src/api/userApi.ts
@@ -1,0 +1,56 @@
+import { SupabaseDatabase } from "@/types/supabaseDataType";
+import { useQuery } from "@tanstack/react-query";
+
+// supabase에서 로그인 정보 가져오기
+export const getUser = async (supabaseClient: SupabaseDatabase) => {
+  const {
+    data: { user },
+    error
+  } = await supabaseClient.auth.getUser();
+
+  if (error || !user) {
+    console.error(error);
+    return;
+  }
+
+  return user;
+};
+
+// 로그인 정보 가져오기
+export const useUserQuery = (supabaseClient: SupabaseDatabase) => {
+  const {
+    data: user,
+    isLoading: isUserLoading,
+    isError: isUserError
+  } = useQuery({
+    queryKey: ["user", "client"],
+    queryFn: () => getUser(supabaseClient)
+  });
+
+  return { user, isUserLoading, isUserError };
+};
+
+// supabase에서 children table에서 user가 등록한 아이들 정보 가져오기
+export const getChildren = async (supabaseClient: SupabaseDatabase, userId?: string) => {
+  if (userId) {
+    const { data, error } = await supabaseClient.from("child").select().eq("user_id", userId);
+
+    if (error) {
+      console.error(error.message);
+      return;
+    }
+
+    return data;
+  } else {
+    return;
+  }
+};
+
+// 사용자의 아이들 정보 가져오기
+export const useChildrenQuery = (supabaseClient: SupabaseDatabase, userId?: string) => {
+  return useQuery({
+      queryKey: ["child_info", userId],
+      queryFn: () => getChildren(supabaseClient, userId),
+      enabled: !!userId
+    });
+};

--- a/src/api/vaccineApi.ts
+++ b/src/api/vaccineApi.ts
@@ -1,7 +1,7 @@
 import { SupabaseDatabase } from "@/types/supabaseDataType";
 import { useQuery } from "@tanstack/react-query";
 import { Tables } from "../../database.types";
-import { addDays, addMonths, format, isAfter, isBefore, isEqual, parse } from "date-fns";
+import { addDays, addMonths, format, isBefore, isEqual } from "date-fns";
 
 export const getVaccines = async (supabaseClient: SupabaseDatabase) => {
   const { data, error } = await supabaseClient.from("vaccine").select().order("vaccine_turn", { ascending: true });
@@ -26,13 +26,19 @@ export const getVaccineSchedule = async (supabaseClient: SupabaseDatabase) => {
 
 export const useVaccineScheduleQuery = (supabaseClient: SupabaseDatabase) => {
   return useQuery({
-    queryKey: ["vaccineCalendar"],
-    queryFn: () => getVaccineSchedule(supabaseClient)
+    queryKey: ["vaccine_schedule"],
+    queryFn: () => getVaccineSchedule(supabaseClient),
+    staleTime: Infinity
   });
 };
 
+export interface vaccineSchedule extends Omit<Tables<'vaccine'>, 'vaccinae_date' | 'duration'> {
+  startDate: string;
+  endDate: string;
+};
+
 // 생일에 따라 접종 일정 계산하기
-export const calculateSchedule = (date?: string, schedules?: Tables<"vaccine">[]) => {
+export const calculateSchedule = (date?: string, schedules?: Tables<"vaccine">[]): Map<string, vaccineSchedule[]> | null => {
   if (!date || !schedules) {
     return null;
   }

--- a/src/api/vaccineApi.ts
+++ b/src/api/vaccineApi.ts
@@ -1,4 +1,7 @@
 import { SupabaseDatabase } from "@/types/supabaseDataType";
+import { useQuery } from "@tanstack/react-query";
+import { Tables } from "../../database.types";
+import { addDays, addMonths, format, isAfter, isBefore, isEqual, parse } from "date-fns";
 
 export const getVaccines = async (supabaseClient: SupabaseDatabase) => {
   const { data, error } = await supabaseClient.from("vaccine").select().order("vaccine_turn", { ascending: true });
@@ -6,4 +9,96 @@ export const getVaccines = async (supabaseClient: SupabaseDatabase) => {
   if (error) throw Error(error.message);
 
   return data;
+};
+
+export const getVaccineSchedule = async (supabaseClient: SupabaseDatabase) => {
+  const { data, error } = await supabaseClient
+    .from("vaccine")
+    .select("*")
+    .order("vaccinate_date", { ascending: true })
+    .order("disease_name", { ascending: true })
+    .order("vaccine_turn", { ascending: true });
+
+  if (error) throw Error(error.message);
+
+  return data;
+};
+
+export const useVaccineScheduleQuery = (supabaseClient: SupabaseDatabase) => {
+  return useQuery({
+    queryKey: ["vaccineCalendar"],
+    queryFn: () => getVaccineSchedule(supabaseClient)
+  });
+};
+
+// 생일에 따라 접종 일정 계산하기
+export const calculateSchedule = (date?: string, schedules?: Tables<"vaccine">[]) => {
+  if (!date || !schedules) {
+    return null;
+  }
+  const birthday = new Date(date);
+  const mySchedule = new Map();
+  const lastMonth = addDays(addMonths(addMonths(birthday, 12 * 12), 12), -1);
+
+  // 비어 있는 달이 존재할 수 이어서 key를 먼저 생성
+  let currentDate = birthday;
+  while (isBefore(currentDate, lastMonth) || isEqual(addDays(currentDate, -1), lastMonth)) {
+    mySchedule.set(format(currentDate, "yyyy.MM"), []);
+    currentDate = addMonths(currentDate, 1);
+  }
+
+  for (const schedule of schedules) {
+    const { id, vaccine_name, disease_name, vaccinate_date, duration, additional, vaccine_turn } = schedule;
+    // console.log(vaccine_name, disease_name, vaccinate_date, duration)
+    const [after, unit] = duration.split(" ");
+    const startDate = addMonths(birthday, vaccinate_date);
+    const startDateFormatted = format(startDate, "yyyy.MM.dd");
+
+    if (unit === "일") {
+      // 일 단위
+      const startDate = addMonths(birthday, vaccinate_date);
+      const startDateFormatted = format(startDate, "yyyy.MM.dd");
+      const startMonthFormatted = format(startDate, "yyyy.MM");
+      mySchedule.set(
+        startMonthFormatted,
+        mySchedule.get(startMonthFormatted).concat([
+          {
+            id,
+            vaccine_name,
+            disease_name,
+            additional,
+            vaccine_turn,
+            startDate: startDateFormatted,
+            endDate: startDateFormatted
+          }
+        ])
+      );
+    } else {
+      // 개월 단위
+      const endDate = addDays(addMonths(addMonths(birthday, vaccinate_date), Number(after)), -1);
+      const endDateFormatted = format(endDate, "yyyy.MM.dd");
+
+      let currentDate = startDate;
+      while (isBefore(currentDate, endDate) || isEqual(addDays(currentDate, -1), endDate)) {
+        const currentMonthFormatted = format(currentDate, "yyyy.MM");
+        mySchedule.set(
+          currentMonthFormatted,
+          mySchedule.get(currentMonthFormatted).concat([
+            {
+              id,
+              vaccine_name,
+              disease_name,
+              additional,
+              vaccine_turn,
+              startDate: startDateFormatted,
+              endDate: endDateFormatted
+            }
+          ])
+        );
+        currentDate = addMonths(currentDate, 1);
+      }
+    }
+  }
+
+  return mySchedule;
 };

--- a/src/app/child/register/steps/RegisterStep1.tsx
+++ b/src/app/child/register/steps/RegisterStep1.tsx
@@ -82,7 +82,7 @@ const RegisterStep1 = ({ onNext }: RegisterStep1Props) => {
           user_id: testUserId, // 테스트용
           name: name,
           birth: birthday,
-          profile: profileImageUrl,
+          profile: profileImageUrl ?? "",
           notes: notes || "" // notes가 없을 경우 빈 문자열로 설정
         }
       ]);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,4 @@
+import Schedule from "@/components/child/Schedule";
 import Link from "next/link";
 
 const HomePage = () => {
@@ -11,6 +12,8 @@ const HomePage = () => {
         <Link href={"/signin"}>로그인</Link>
         <Link href={"/signup"}>회원가입</Link>
       </div>
+
+      <Schedule/>
     </>
   );
 };

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,9 +8,7 @@ const HomePage = () => {
       <div className="flex gap-2">
         <Link href={"/search"}>병원검색</Link>
         <Link href={"/vaccineinfo"}>접종 정보</Link>
-        <Link href={"child"}>우리 아이 맞춤형</Link>
-        <Link href={"/signin"}>로그인</Link>
-        <Link href={"/signup"}>회원가입</Link>
+        <Link href={"/child"}>우리 아이 맞춤형</Link>
       </div>
 
       <Schedule/>

--- a/src/components/child/Schedule.tsx
+++ b/src/components/child/Schedule.tsx
@@ -1,10 +1,9 @@
 "use client";
 
 import { useChildrenQuery, useUserQuery } from "@/api/userApi";
-import { calculateSchedule, useVaccineScheduleQuery } from "@/api/vaccineApi";
 import browserClient from "@/utils/supabase/client";
 import React from "react";
-import { addDays, addMonths, format } from "date-fns";
+import ScheduleCarousel from "./ScheduleCarousel";
 
 // 나중에 input으로 받을 것
 // child: 아이 정보
@@ -16,28 +15,23 @@ const Schedule = () => {
   const { user, isUserLoading, isUserError } = useUserQuery(browserClient);
 
   const {
-    data: schedule,
-    isLoading: isScheduleLoading,
-    isError: isScheduleError
-  } = useVaccineScheduleQuery(browserClient);
-
-  const {
     data: childrenData,
     isLoading: isChildrenLoading,
     isError: isChildrenError
   } = useChildrenQuery(browserClient, user?.id);
 
-  if (isUserLoading || isChildrenLoading || isScheduleLoading) {
+  if (isUserLoading || isChildrenLoading) {
     return <div>Loading...</div>;
   }
 
-  if (isUserError || isChildrenError || isScheduleError) {
+  if (isUserError || isChildrenError) {
     return <div>Error.</div>;
   }
 
   return (
-    <div>
+    <div className="mx-auto">
       <p>Schedule</p>
+      <ScheduleCarousel child={childrenData?.[0]} />
     </div>
   );
 };

--- a/src/components/child/Schedule.tsx
+++ b/src/components/child/Schedule.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useChildrenQuery, useUserQuery } from "@/api/userApi";
+import { calculateSchedule, useVaccineScheduleQuery } from "@/api/vaccineApi";
+import browserClient from "@/utils/supabase/client";
+import React from "react";
+import { addDays, addMonths, format } from "date-fns";
+
+// 나중에 input으로 받을 것
+// child: 아이 정보
+// 접종 일정도 상위에서 한번만 가져와서 같이 뿌려주면 좋을 듯
+
+// 추후 해야할 것
+// 접종 정보 가져와서 받은 백신 표시하기
+const Schedule = () => {
+  const { user, isUserLoading, isUserError } = useUserQuery(browserClient);
+
+  const {
+    data: schedule,
+    isLoading: isScheduleLoading,
+    isError: isScheduleError
+  } = useVaccineScheduleQuery(browserClient);
+
+  const {
+    data: childrenData,
+    isLoading: isChildrenLoading,
+    isError: isChildrenError
+  } = useChildrenQuery(browserClient, user?.id);
+
+  if (isUserLoading || isChildrenLoading || isScheduleLoading) {
+    return <div>Loading...</div>;
+  }
+
+  if (isUserError || isChildrenError || isScheduleError) {
+    return <div>Error.</div>;
+  }
+
+  return (
+    <div>
+      <p>Schedule</p>
+    </div>
+  );
+};
+
+export default Schedule;

--- a/src/components/child/ScheduleCarousel.tsx
+++ b/src/components/child/ScheduleCarousel.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import React from "react";
+import { Tables } from "../../../database.types";
+import { calculateSchedule, useVaccineScheduleQuery } from "@/api/vaccineApi";
+import browserClient from "@/utils/supabase/client";
+import { Carousel, CarouselContent, CarouselItem, CarouselNext, CarouselPrevious } from "@/components/ui/carousel";
+
+// 여기서 child id에 대한 vaccine record를 가져와서 vaccine id가 포함되어 있으면 
+const ScheduleCarousel = ({ child }: { child?: Tables<"child"> }) => {
+  const { data: schedule, isLoading, isError } = useVaccineScheduleQuery(browserClient);
+
+  const childSchedule = calculateSchedule(child?.birth, schedule);
+
+  if (isLoading) {
+    return <div>아이 카드 접종 일정표 Loading....</div>;
+  }
+  if (isError) {
+    return <div>아이 카드 접종 일정표 Error</div>;
+  }
+
+  return (
+    <Carousel className="w-full max-w-xs">
+      <CarouselContent>
+        {Array.from(childSchedule?.entries() || []).map((schedule, index) => {
+          const [month, vaccines] = schedule;
+          return (
+            <CarouselItem key={index}>
+              <div className="flex flex-col p-1">
+                <p className="mx-auto">{month}</p>
+                <div>
+                  <ul>
+                    {vaccines.length === 0 ? <li>접종 일정이 없습니다.</li>:vaccines.map(vaccine => (<li key={`${month}_${vaccine.id}`}>{vaccine.disease_name} - {vaccine.vaccine_name}</li>))}
+                  </ul>
+                </div>
+              </div>
+            </CarouselItem>
+          );
+        })}
+      </CarouselContent>
+      <CarouselPrevious className="top-0 left-0 translate-y-0"/>
+      <CarouselNext className="top-0 right-0 translate-y-0"/>
+    </Carousel>
+  );
+};
+
+export default ScheduleCarousel;

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import React from "react";
+import TmpSignOut from "./TmpSignOut";
 
 const Header = async () => {
   // const user = await fetchCurrentUser();
@@ -33,6 +34,9 @@ const Header = async () => {
                 <Link className="font-medium" href={"/signup"}>
                   회원가입
                 </Link>
+              </li>
+              <li>
+                <TmpSignOut/>
               </li>
             {/* </>
           ) : (

--- a/src/components/layout/TmpSignOut.tsx
+++ b/src/components/layout/TmpSignOut.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+import React from 'react'
+import { Button } from '../ui/button'
+import browserClient from '@/utils/supabase/client'
+
+const TmpSignOut = () => {
+
+  return (
+    <Button onClick={() => {
+      browserClient.auth.signOut()
+    }}>로그아웃</Button>
+  )
+}
+
+export default TmpSignOut

--- a/src/components/ui/carousel.tsx
+++ b/src/components/ui/carousel.tsx
@@ -1,0 +1,262 @@
+"use client"
+
+import * as React from "react"
+import useEmblaCarousel, {
+  type UseEmblaCarouselType,
+} from "embla-carousel-react"
+import { ArrowLeft, ArrowRight } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+
+type CarouselApi = UseEmblaCarouselType[1]
+type UseCarouselParameters = Parameters<typeof useEmblaCarousel>
+type CarouselOptions = UseCarouselParameters[0]
+type CarouselPlugin = UseCarouselParameters[1]
+
+type CarouselProps = {
+  opts?: CarouselOptions
+  plugins?: CarouselPlugin
+  orientation?: "horizontal" | "vertical"
+  setApi?: (api: CarouselApi) => void
+}
+
+type CarouselContextProps = {
+  carouselRef: ReturnType<typeof useEmblaCarousel>[0]
+  api: ReturnType<typeof useEmblaCarousel>[1]
+  scrollPrev: () => void
+  scrollNext: () => void
+  canScrollPrev: boolean
+  canScrollNext: boolean
+} & CarouselProps
+
+const CarouselContext = React.createContext<CarouselContextProps | null>(null)
+
+function useCarousel() {
+  const context = React.useContext(CarouselContext)
+
+  if (!context) {
+    throw new Error("useCarousel must be used within a <Carousel />")
+  }
+
+  return context
+}
+
+const Carousel = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement> & CarouselProps
+>(
+  (
+    {
+      orientation = "horizontal",
+      opts,
+      setApi,
+      plugins,
+      className,
+      children,
+      ...props
+    },
+    ref
+  ) => {
+    const [carouselRef, api] = useEmblaCarousel(
+      {
+        ...opts,
+        axis: orientation === "horizontal" ? "x" : "y",
+      },
+      plugins
+    )
+    const [canScrollPrev, setCanScrollPrev] = React.useState(false)
+    const [canScrollNext, setCanScrollNext] = React.useState(false)
+
+    const onSelect = React.useCallback((api: CarouselApi) => {
+      if (!api) {
+        return
+      }
+
+      setCanScrollPrev(api.canScrollPrev())
+      setCanScrollNext(api.canScrollNext())
+    }, [])
+
+    const scrollPrev = React.useCallback(() => {
+      api?.scrollPrev()
+    }, [api])
+
+    const scrollNext = React.useCallback(() => {
+      api?.scrollNext()
+    }, [api])
+
+    const handleKeyDown = React.useCallback(
+      (event: React.KeyboardEvent<HTMLDivElement>) => {
+        if (event.key === "ArrowLeft") {
+          event.preventDefault()
+          scrollPrev()
+        } else if (event.key === "ArrowRight") {
+          event.preventDefault()
+          scrollNext()
+        }
+      },
+      [scrollPrev, scrollNext]
+    )
+
+    React.useEffect(() => {
+      if (!api || !setApi) {
+        return
+      }
+
+      setApi(api)
+    }, [api, setApi])
+
+    React.useEffect(() => {
+      if (!api) {
+        return
+      }
+
+      onSelect(api)
+      api.on("reInit", onSelect)
+      api.on("select", onSelect)
+
+      return () => {
+        api?.off("select", onSelect)
+      }
+    }, [api, onSelect])
+
+    return (
+      <CarouselContext.Provider
+        value={{
+          carouselRef,
+          api: api,
+          opts,
+          orientation:
+            orientation || (opts?.axis === "y" ? "vertical" : "horizontal"),
+          scrollPrev,
+          scrollNext,
+          canScrollPrev,
+          canScrollNext,
+        }}
+      >
+        <div
+          ref={ref}
+          onKeyDownCapture={handleKeyDown}
+          className={cn("relative", className)}
+          role="region"
+          aria-roledescription="carousel"
+          {...props}
+        >
+          {children}
+        </div>
+      </CarouselContext.Provider>
+    )
+  }
+)
+Carousel.displayName = "Carousel"
+
+const CarouselContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => {
+  const { carouselRef, orientation } = useCarousel()
+
+  return (
+    <div ref={carouselRef} className="overflow-hidden">
+      <div
+        ref={ref}
+        className={cn(
+          "flex",
+          orientation === "horizontal" ? "-ml-4" : "-mt-4 flex-col",
+          className
+        )}
+        {...props}
+      />
+    </div>
+  )
+})
+CarouselContent.displayName = "CarouselContent"
+
+const CarouselItem = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => {
+  const { orientation } = useCarousel()
+
+  return (
+    <div
+      ref={ref}
+      role="group"
+      aria-roledescription="slide"
+      className={cn(
+        "min-w-0 shrink-0 grow-0 basis-full",
+        orientation === "horizontal" ? "pl-4" : "pt-4",
+        className
+      )}
+      {...props}
+    />
+  )
+})
+CarouselItem.displayName = "CarouselItem"
+
+const CarouselPrevious = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentProps<typeof Button>
+>(({ className, variant = "outline", size = "icon", ...props }, ref) => {
+  const { orientation, scrollPrev, canScrollPrev } = useCarousel()
+
+  return (
+    <Button
+      ref={ref}
+      variant={variant}
+      size={size}
+      className={cn(
+        "absolute  h-8 w-8 rounded-full",
+        orientation === "horizontal"
+          ? "-left-12 top-1/2 -translate-y-1/2"
+          : "-top-12 left-1/2 -translate-x-1/2 rotate-90",
+        className
+      )}
+      disabled={!canScrollPrev}
+      onClick={scrollPrev}
+      {...props}
+    >
+      <ArrowLeft className="h-4 w-4" />
+      <span className="sr-only">Previous slide</span>
+    </Button>
+  )
+})
+CarouselPrevious.displayName = "CarouselPrevious"
+
+const CarouselNext = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentProps<typeof Button>
+>(({ className, variant = "outline", size = "icon", ...props }, ref) => {
+  const { orientation, scrollNext, canScrollNext } = useCarousel()
+
+  return (
+    <Button
+      ref={ref}
+      variant={variant}
+      size={size}
+      className={cn(
+        "absolute h-8 w-8 rounded-full",
+        orientation === "horizontal"
+          ? "-right-12 top-1/2 -translate-y-1/2"
+          : "-bottom-12 left-1/2 -translate-x-1/2 rotate-90",
+        className
+      )}
+      disabled={!canScrollNext}
+      onClick={scrollNext}
+      {...props}
+    >
+      <ArrowRight className="h-4 w-4" />
+      <span className="sr-only">Next slide</span>
+    </Button>
+  )
+})
+CarouselNext.displayName = "CarouselNext"
+
+export {
+  type CarouselApi,
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselPrevious,
+  CarouselNext,
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1155,6 +1155,11 @@ data-view-byte-offset@^1.0.0:
     es-errors "^1.3.0"
     is-data-view "^1.0.1"
 
+date-fns@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-4.1.0.tgz#64b3d83fff5aa80438f5b1a633c2e83b8a1c2d14"
+  integrity sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==
+
 debug@4, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.3.5:
   version "4.3.7"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.7.tgz#87945b4151a011d76d95a198d7111c865c360a52"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1231,6 +1231,24 @@ eastasianwidth@^0.2.0:
   resolved "https://registry.yarnpkg.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz#696ce2ec0aa0e6ea93a397ffcf24aa7840c827cb"
   integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
 
+embla-carousel-react@^8.3.1:
+  version "8.3.1"
+  resolved "https://registry.yarnpkg.com/embla-carousel-react/-/embla-carousel-react-8.3.1.tgz#f6d91f484b00704411524cf01feb80fdcff7dde2"
+  integrity sha512-gBY0zM+2ASvKFwRpTIOn2SLifFqOKKap9R/y0iCpJWS3bc8OHVEn2gAThGYl2uq0N+hu9aBiswffL++OYZOmDQ==
+  dependencies:
+    embla-carousel "8.3.1"
+    embla-carousel-reactive-utils "8.3.1"
+
+embla-carousel-reactive-utils@8.3.1:
+  version "8.3.1"
+  resolved "https://registry.yarnpkg.com/embla-carousel-reactive-utils/-/embla-carousel-reactive-utils-8.3.1.tgz#8e92407f92f55e5f38ef22d24c018077476f1e11"
+  integrity sha512-Js6rTTINNGnUGPu7l5kTcheoSbEnP5Ak2iX0G9uOoI8okTNLMzuWlEIpYFd1WP0Sq82FFcLkKM2oiO6jcElZ/Q==
+
+embla-carousel@8.3.1:
+  version "8.3.1"
+  resolved "https://registry.yarnpkg.com/embla-carousel/-/embla-carousel-8.3.1.tgz#8f5dcd0dc001977efd2bca54d620b6e6736a1a85"
+  integrity sha512-DutFjtEO586XptDn4cwvBJwsR/8fMa4jUk5Jk2g+/elKgu8mdn0Z2sx33g4JskvbLc1/6P8Xg4QlfELGJFcP5A==
+
 emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"


### PR DESCRIPTION
## 🔥 작업 내용

- 아이 생일을 input으로 받으면 접종 일정에 따라 월별로 계산해주는 함수 만들기
- 아이카드 일정표에 접종 일정 보여주기 및 캐러셀 적용 완료

## 📸 스크린샷

- 캐러셀이 잘 적용되었습니다.
![image](https://github.com/user-attachments/assets/66546272-2da5-47af-821e-07bcb7a99840)


## 💁🏻‍♀️ 테스트 체크리스트

- 로그아웃하면 Error 띄워줍니다.
- 로그인하면 아이 정보가 있을 시 캐러셀을 만들어 줍니다.

## 👍 참고 사항

- 2024.02.29와 같은 특수한 날은 좀 계산이 '예방접종 도우미'에서 뜨는 결과와 하루 정도 차이가 납니다.
- 'date-fns' 라이브러리를 사용했습니다.
- 임시로 로그아웃 버튼을 넣었습니다. 나중에 삭제해주시면 감사하겠습니다.
