### PR TITLE
Feat/vaccineinfo: 백신리스트 페이지네이션 적용

### DIFF
--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -19,7 +19,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-10 w-full items-center justify-between rounded-lg border border-neutral-200 bg-white px-3 py-2 text-base placeholder:text-gray-300 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1 dark:border-neutral-800 dark:bg-neutral-950 dark:ring-offset-neutral-950 dark:placeholder:text-neutral-400 dark:focus:ring-neutral-300",
+      "flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
       className
     )}
     {...props}
@@ -68,7 +68,7 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-lg border-0 bg-gray-30 text-neutral-950 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-50",
+        "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-lg border-0 bg-white text-neutral-950 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-50",
         position === "popper" &&
           "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
         className
@@ -107,7 +107,7 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex w-full select-none items-center rounded-sm py-1.5 px-2 text-gray-800 text-base outline-none cursor-pointer data-[disabled]:pointer-events-none data-[disabled]:opacity-50 dark:focus:bg-neutral-800 dark:focus:text-neutral-50",
+      "relative flex w-full h-[42px] select-none items-center rounded-sm py-1.5 px-2 text-gray-800 text-base outline-none cursor-pointer hover:bg-gray-30 data-[disabled]:pointer-events-none data-[disabled]:opacity-50 dark:focus:bg-neutral-800 dark:focus:text-neutral-50",
       className
     )}
     {...props}

--- a/src/components/vaccineinfo/VaccineList.tsx
+++ b/src/components/vaccineinfo/VaccineList.tsx
@@ -3,22 +3,60 @@
 import { useVaccineInfoQuery } from "@/query/useVaccineInfoQuery";
 import { useAgeGroupStore } from "@/utils/zustand/ageGroupStore";
 import VaccineCard from "./vaccineCard";
+import { useMemo, useState } from "react";
+import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious
+} from "../ui/pagination";
+
+const ITEMS_PER_PAGE = 6;
 
 const VaccineList = () => {
+  const [page, setPage] = useState(1);
   const { selectedAge } = useAgeGroupStore();
+  const { data: allData, error, isPending } = useVaccineInfoQuery();
 
-  const { data, error, isPending } = useVaccineInfoQuery();
+  // 선택된 연령에 따라 데이터 필터링
+  const filteredData = useMemo(() => {
+    if (!allData) return [];
+    return selectedAge === 1000
+      ? allData
+      : allData.filter((item) => JSON.parse(item.vaccinate_date || "[]").includes(selectedAge));
+  }, [allData, selectedAge]);
+
+  // 총 페이지 수 계산
+  const totalPages = Math.ceil(filteredData.length / ITEMS_PER_PAGE);
+
+  // 현재 페이지에 해당하는 데이터 계산
+  const currentPageData = useMemo(() => {
+    const startIndex = (page - 1) * ITEMS_PER_PAGE;
+    const endIndex = startIndex + ITEMS_PER_PAGE;
+    return filteredData.slice(startIndex, endIndex);
+  }, [filteredData, page]);
+
+  // 페이지가 유효 범위를 벗어나면 첫 페이지로 리셋
+  useMemo(() => {
+    if (page > totalPages) {
+      setPage(1);
+    }
+  }, [totalPages, page]);
+
   if (isPending) return "접종 정보 로딩중...";
   if (error) throw new Error(`Error: ${error}`);
 
-  const formattedData =
-    selectedAge === 1000 ? data : data.filter((item) => JSON.parse(item.vaccinate_date || "").includes(selectedAge));
-  // console.log(data);
+  const handlePage = (newPage: number) => {
+    if (newPage < 1 || newPage > totalPages) return;
+    setPage(newPage);
+  };
 
   return (
-    <div className="grid grid-cols-2 gap-6 min-h-[800px]">
-      {formattedData?.map((item) => {
-        return (
+    <>
+      <div className="grid grid-cols-2 gap-6 min-h-[800px]">
+        {currentPageData.map((item) => (
           <VaccineCard
             key={item.id}
             disease={item.disease_name}
@@ -26,9 +64,26 @@ const VaccineList = () => {
             target={item.target}
             process={item.process}
           />
-        );
-      })}
-    </div>
+        ))}
+      </div>
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationPrevious href="#" onClick={() => handlePage(page - 1)} isActive={page > 1} />
+          </PaginationItem>
+          {[...Array(totalPages)].map((_, index) => (
+            <PaginationItem key={index}>
+              <PaginationLink href="#" onClick={() => handlePage(index + 1)} isActive={page === index + 1}>
+                {index + 1}
+              </PaginationLink>
+            </PaginationItem>
+          ))}
+          <PaginationItem>
+            <PaginationNext href="#" onClick={() => handlePage(page + 1)} isActive={page < totalPages} />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>
+    </>
   );
 };
 

--- a/src/components/vaccineinfo/VaccineList.tsx
+++ b/src/components/vaccineinfo/VaccineList.tsx
@@ -16,7 +16,7 @@ const VaccineList = () => {
   // console.log(data);
 
   return (
-    <div className="grid grid-cols-2 gap-6">
+    <div className="grid grid-cols-2 gap-6 min-h-[800px]">
       {formattedData?.map((item) => {
         return (
           <VaccineCard

--- a/src/components/vaccineinfo/vaccineCard.tsx
+++ b/src/components/vaccineinfo/vaccineCard.tsx
@@ -19,7 +19,7 @@ const VaccineCard = ({
     <div
       className={`${
         vaccineId === vaccine ? "border-primary-400" : ""
-      } border-[2px] border-gray-100 px-14 py-16 flex flex-col gap-8 rounded-3xl`}
+      } border-[2px] border-gray-100 px-14 py-16 flex flex-col gap-8 rounded-3xl max-h-[358px]`}
       onClick={() => {
         setCurrentDisease(disease ?? "");
         setVaccineId(vaccine);


### PR DESCRIPTION
## 🔥 작업 내용

- 백신 리스트 페이지네이션 적용했습니다. 페이지 당 6개 출력
- 백신 리스트 최소 높이 설정으로 하단의 버튼이 따라 올라오지 못하게 했습니다.
- 백신 리스트 컴포넌트 높이에 따라 늘어나던 백신카드 컴포넌트의 최대높이를 제한하여 특정 길이 이상으로 늘어나지 않도록 했습니다.
- shadcn select 컴포넌트 디자인이 수정되었습니다(by조해인)
  

## 📸 스크린샷

- 페이지네이션
![chrome-capture-2024-11-5](https://github.com/user-attachments/assets/527150a2-3f1b-4994-9958-2af1a3ad6477)
- 버튼 높이
![chrome-capture-2024-11-5](https://github.com/user-attachments/assets/44968b5c-df3f-4b1a-b28d-d713d5bf37fe)

## 💁🏻‍♀️ 테스트 체크리스트

- 카테고리 변경 시 페이지가 초기화되지 않습니다.
- 페이지 변경 시 화면이 최상단으로 바뀝니다.

## 👍 참고 사항

- 관련된 이슈나 참고할 사항을 적어주세요!
-
