### PR TITLE
체크리스트fix: 모바일환경에서 버튼 4/1만 보이던 이슈

### DIFF
--- a/src/app/child/[id]/page.tsx
+++ b/src/app/child/[id]/page.tsx
@@ -41,7 +41,7 @@ const VaccineRecordPage = async ({ params }: VaccinatePageProps) => {
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>
-      <div className="flex flex-col min-w-[375px] justify-center items-center mx-auto md:w-[796px] md:gap-20 md:items-start md:my-[100px]">
+      <div className="flex flex-col min-w-[375px] pb-20 justify-center items-center mx-auto md:w-[796px] md:gap-20 md:items-start md:my-[100px]">
         <div className="flex w-full items-start px-6 py-1.5 md:hidden">
           <BackButton childId={childId} />
         </div>

--- a/src/app/child/[id]/record/page.tsx
+++ b/src/app/child/[id]/record/page.tsx
@@ -41,7 +41,7 @@ const VaccineRecordEditPage = async ({ params }: VaccineRecordEditPageProps) => 
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>
-      <div className="flex flex-col min-w-[375px] justify-center items-center mx-auto md:w-[796px] md:gap-20 md:items-start md:my-[100px]">
+      <div className="flex flex-col min-w-[375px] pb-20 justify-center items-center mx-auto md:w-[796px] md:gap-20 md:items-start md:my-[100px]">
         <div className="flex w-full items-start px-6 py-1.5 md:hidden">
           <BackButton childId={childId} />
         </div>

--- a/src/components/vaccinerecord/VaccineRecordTabs.tsx
+++ b/src/components/vaccinerecord/VaccineRecordTabs.tsx
@@ -104,8 +104,8 @@ const VaccineRecordTabs = ({ childId, edit, control }: VaccineRecordProps) => {
               childId={childId}
               onSuccess={onSuccess}
             >
-              <div className="flex flex-col items-start gap-6 relative self-stretch w-full mt-20">
-                <Button className="flex h-[72px] p-[16px 24px] justify-center items-center gap-[10px] self-stretch rounded-xl bg-primary-400 hover:bg-primary-300">
+              <div className="flex w-full mt-9 md:mt-20">
+                <Button className="flex w-full h-14 md:h-[72px] p-[16px 24px] justify-center items-center rounded-xl bg-primary-400 hover:bg-primary-300">
                   등록 완료
                 </Button>
               </div>


### PR DESCRIPTION
## 🔥 작업 내용

- 모바일 환경에서 버튼이 네비바에 가려지는 이슈 (page에서 pb-20)

## 📸 스크린샷

![image](https://github.com/user-attachments/assets/8be3acfc-af48-4e16-a19a-c1d7b67ec7fb)
👇
![image](https://github.com/user-attachments/assets/57bffa50-c367-4f07-85a6-e5c8257fde4a)

